### PR TITLE
Checking if progressBlock not null before calling

### DIFF
--- a/CPAProxy/CPAProxyManager.m
+++ b/CPAProxy/CPAProxyManager.m
@@ -279,7 +279,9 @@ typedef NS_ENUM(NSUInteger, CPAControlPortStatus) {
         __weak typeof(self)weakSelf = self;
         dispatch_async(self.callbackQueue, ^{
             __strong typeof(weakSelf)strongSelf = weakSelf;
-            strongSelf.progressBlock(progress,summaryString);
+            if (strongSelf.progressBlock) {
+                strongSelf.progressBlock(progress,summaryString);
+            }
         });
     }
 


### PR DESCRIPTION
A crash happened to me while debugging. He's checking if progress block is not null only before dispatching to the callback queue.